### PR TITLE
Moved yiisoft/yii2-gii to "dev" dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,12 @@
 
 		"yiisoft/yii2": "~2.0.6",
 		"yiisoft/yii2-bootstrap": "~2.0.0",
-		"yiisoft/yii2-gii": "~2.0.0",
 
 		"yurkinx/yii2-image": "~1.1"
+	},
+
+        "require-dev": {
+	        "yiisoft/yii2-gii": "~2.0.0"
 	},
 
 	"autoload": {


### PR DESCRIPTION
yiisoft/yii2-gii is a development tool and should be marked as such, this avoids version constraint conflicts when asinfotrack/yii2-toolbox is used in other projects.

Composer error example:
```
Problem 1
    - Root composer.json requires asinfotrack/yii2-toolbox ~1.0.6 -> satisfiable by asinfotrack/yii2-toolbox[1.0.6].
    - asinfotrack/yii2-toolbox 1.0.6 requires yiisoft/yii2-gii ~2.0.0 -> found yiisoft/yii2-gii[2.0.0, ..., 2.0.8] but it conflicts with your root composer.json require (~2.2.0).
```